### PR TITLE
Fix compiling LambdaSwitch 

### DIFF
--- a/components/open_lcc_bianca/switch/LambdaSwitch.h
+++ b/components/open_lcc_bianca/switch/LambdaSwitch.h
@@ -6,6 +6,7 @@
 #define LCC_ESPHOME_LAMBDASWITCH_H
 
 #include "esphome.h"
+#include "esphome/components/switch/switch.h"
 #include <functional>
 
 


### PR DESCRIPTION
When I compiled the project I was getting errors that the `switch_` namespace was undeclared. Poking around my generated `esphome.h` file I could see that the includes there were ordered alphabetically, so `open_lcc_bianca/switch/LambdaSwitch.h` came before `switch/switch.h`:

```
$ rg "(LambdaS|switch/s)witch.h" build/smart-lcc/src/esphome.h
60:#include "esphome/components/open_lcc_bianca/switch/LambdaSwitch.h"
85:#include "esphome/components/switch/switch.h"
```

Including `switch.h` directly in this file fixed this. I assume this must be due to a recent-ish change in esphome. My version: 

```bash
$ esphome version
Version: 2023.11.6
```

